### PR TITLE
Remove jQuery dependency

### DIFF
--- a/Kissanime-Downloader.user.js
+++ b/Kissanime-Downloader.user.js
@@ -1,115 +1,40 @@
 // ==UserScript==
 // @name         Kissanime Downloader with Jdownloader
 // @namespace    https://github.com/Meisterlala/Kissanime-Downloader
-// @version      v1
+// @version      v2.0.0
 // @description  Adds Download Button
 // @author       Meisterlala
 // @include      */kissanime.*/Anime/*
 // @exclude      */kissanime.*/Anime/*/*
-// @require      http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js
-// @grant        GM_setValue
-// @grant        GM_getValue
 // @grant        GM_setClipboard
-// @grant        unsafeWindow
-// @grant        GM_log
 // @grant        GM_addStyle
 // @noframes
 // ==/UserScript==
 
+// Adds the CSS for button formatting
+var maincolor = window.getComputedStyle ( document.querySelector ( '.bigChar' ) ).color;
+GM_addStyle('#myButton{z-index:222;cursor:pointer;position:relative;margin-right:15px;background-color:transparent;outline:0;border:none;\n' +
+'display:inline-block;text-decoration:none;font:400 27px Tahoma,Arial,Helvetica,sans-serif;transition-duration:.4s;border-radius:4px;\n' +
+'color:' + maincolor + '}#myButton:hover{color:#000;background-color:' + maincolor + '}#myButtonContainer{text-align:center}');
 
+// Adds the button to the page
+let container = document.createElement ( 'div' );
+container.setAttribute ( 'id', 'myButtonContainer' );
 
-var setClipboard = " --ERROR-- "
+let button = document.createElement ( 'button' );
+button.setAttribute ( 'type', 'button' );
+button.setAttribute ( 'id', 'myButton' );
+button.innerHTML = 'Download with JDownloader';
 
+let containerContainer = document.querySelector ( '.barContent > div:nth-child(2)' );
 
-
-function main() {
-
-    //alert(window.location.href)
-    var urlnamelong = window.location.href.search("Anime");
-    var urlname = window.location.href.substr(urlnamelong + 6);
-    var clipboard = $("a[href*=\"" + urlname + "/Episode-" + "\"]").attr('href');
-    var epilist = [];
-    $("a[href*=\"" + urlname + "/Episode-" + "\"]").each( function() {
-
-        epilist.push("http://kissanime.com" + $(this).attr('href'));
-
-    });
-    epilist.pop();
-    epilist = epilist.sort();
-
-    setClipboard = epilist.toString()
-    GM_setClipboard(setClipboard);
-    
-     
-}
-
-
-
-
-
-
-var appendedHTML = `          
-    
-    <div id="myButtonContainer">
-    <button id="myButton" type="button">
-    Download with JDownloader
-    </button>           
-    </div>
-    
-`;
-
-$("div.bigBarContainer:nth-child(1) > div:nth-child(2) > div:nth-child(2)").append(appendedHTML);
-
-var maincolor = $("div.bigBarContainer:nth-child(1) > div:nth-child(2) > div:nth-child(2) > p:nth-child(2) > a:nth-child(2)").css("color")
-var cssstyle = `
-
-
-    #myButton {
-        z-index:                222;
-        cursor:                 pointer;
-        position:               relative;
-        margin-right:           15px;
-        font-size:              18px;
-        background-color:       transparent;
-        outline:                none;
-        border:                 none;
-        display:                inline-block;
-        text-decoration:        none;
-        font:                   normal 27px "Tahoma" , Arial, Helvetica, sans-serif;
-        transition-duration:    0.4s;
-        border-radius:          4px;
-		` + "color:                  " + maincolor +`
-    }
-    #myButton:hover {
-        color:                  black;
-        ` + "background-color:       " + maincolor +`       
-    }
-    #myButtonContainer {
-        
-        text-align:             center;
-        
-    }
-	`
-	
-GM_addStyle(cssstyle);
-
-
-
-
-// $("#myButton").css("color", maincolor)
-// $("#myButton:hover").css("background-color:", maincolor)
-
+container.appendChild ( button );
+containerContainer.appendChild ( container );
 
 // Activate the added button
-document.getElementById("myButton").addEventListener (
-    "click", ButtonClickAction, false
-);
-
-function ButtonClickAction (zEvent) {
-    main();    
-}
-
-
-
-
-//jQ('a[href^="\\/Anime\\/" + name + "\\/Episode\\-*"]')
+button.addEventListener ( 'click', function ( ) {
+    GM_setClipboard ( Array.prototype.slice.call ( document.querySelectorAll ( '.episodeList a[href*=Episode]' ) )
+                     .map ( elem => document.location.protocol + '//' + document.location.hostname + elem.getAttribute ( 'href' ) )
+                     .reverse ( )
+                     .join ( '\n' ) );
+}, false );

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Download an entire anime series with just a few button presses. Supports many di
 </p>
 ![packagizer](https://cloud.githubusercontent.com/assets/6453306/16174827/24d95554-35d6-11e6-9929-9aba4f89a37b.gif)
 # Usage
-###### 1. Visit [KissAnime.to][kissanime]
+###### 1. Visit [KissAnime.ru][kissanime]
 ###### 2. Click on **Download with JDownloader**
 ###### 3. Start JDownloader 2 and enable the [Clipboard Observer](http://jdownloader.org/knowledge/wiki/gui/mainpanel#enabledisable-clipboard-observer)
 ###### 4. Wait about 7s for each episode that has to be loaded
@@ -37,5 +37,5 @@ Download an entire anime series with just a few button presses. Supports many di
 [Tampermonkey]: https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo
 [main.js]: ../../raw/master/Kissanime-Downloader.user.js
 [.packagizer]: ../../raw/master/Kissanime-Downloader.packagizer
-[kissanime]: http://kissanime.to/
+[kissanime]: http://kissanime.ru/
 [greasyfork]: https://greasyfork.org/scripts/20724-kissanime-downloader-with-jdownloader/code/Kissanime%20Downloader%20with%20Jdownloader.user.js


### PR DESCRIPTION
I made the following changes:
- Removed jQuery (no need to load a huge library for some simple actions that can be done without it)
- Removed ES6 strings (better compatibility with other browsers)
- Removed unneeded `@grant`s (might confuse people checking the code)
- Minified the CSS (uses less space)
- Reduced overall code size (removing jQuery , removing unneeded `@grant`s and minifying the CSS ended up making the code smaller)
- Bumped version number to 2.0.0 (removing jQuery is what i'd consider a big change, so I bumped the version number)

Thank you for providing us with this script, it helped me on many occasions.
I hope my changes prove to be helpful.